### PR TITLE
Speed up the colors/variables extractions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "icon": "assets/logo.png",
   "engines": {
-    "vscode": "^1.17.0"
+    "vscode": "^1.18.0"
   },
   "categories": [
     "Other"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,12 +25,12 @@ import {
 } from 'vscode';
 import Color, { IColor } from './lib/colors/color';
 import Variable from './lib/variables/variable';
-import ColorUtil, { IDecoration } from './lib/color-util';
+import ColorUtil, { IDecoration, DocumentLine, LineExtraction } from './lib/color-util';
 import ColorDecoration from './lib/colors/color-decoration';
 import Queue from './lib/queue';
-import ColorExtractor, { LineExtraction } from './lib/colors/color-extractor';
+import ColorExtractor from './lib/colors/color-extractor';
 import VariableDecoration from './lib/variables/variable-decoration';
-import VariablesManager, { DocumentLine } from './lib/variables/variables-manager';
+import VariablesManager from './lib/variables/variables-manager';
 import CacheManager from './lib/cache-manager';
 import EditorManager from './lib/editor-manager';
 import color from './lib/colors/color';

--- a/src/lib/color-util.ts
+++ b/src/lib/color-util.ts
@@ -4,9 +4,10 @@ import './colors/extractors/hexa-extractor';
 import './colors/extractors/rgb-extractor';
 import './colors/extractors/browser-extractor';
 import './colors/extractors/hsl-extractor';
-import ColorExtractor from './colors/color-extractor';
+import ColorExtractor, { LineExtraction } from './colors/color-extractor';
 import ColorDecoration from './colors/color-decoration';
 import { Range, TextEditorDecorationType } from 'vscode';
+import { DocumentLine } from './variables/variables-manager';
 
 const WHITE = '#FFFFFF',
       BLACK = '#000000';
@@ -41,8 +42,14 @@ interface IDecoration {
   generateRange(line: number): Range;
 }
 
-
 class ColorUtil {
+  public static textToFileLines(text: string): DocumentLine[] {
+    return text.split(/\n/)
+                .map((text, index) => Object({
+                  'text': text,
+                  'line': index
+                }));
+  }
   /**
    * Extract all colors from a text
    *
@@ -52,10 +59,9 @@ class ColorUtil {
    *
    * @memberOf ColorUtil
    */
-   public static async findColors(text, fileName = null): Promise < IColor[] > {
-    const colors = await ColorExtractor.extract(text);
-    return colors;
-   }
+  public static async findColors(fileContent: DocumentLine[], fileName = null): Promise < LineExtraction[] > {
+    return await ColorExtractor.extract(fileContent);
+  }
 
   public static generateDecoration(color: IColor): IDecoration {
     return new ColorDecoration(<Color>color);

--- a/src/lib/color-util.ts
+++ b/src/lib/color-util.ts
@@ -4,10 +4,21 @@ import './colors/extractors/hexa-extractor';
 import './colors/extractors/rgb-extractor';
 import './colors/extractors/browser-extractor';
 import './colors/extractors/hsl-extractor';
-import ColorExtractor, { LineExtraction } from './colors/color-extractor';
+import ColorExtractor from './colors/color-extractor';
 import ColorDecoration from './colors/color-decoration';
 import { Range, TextEditorDecorationType } from 'vscode';
-import { DocumentLine } from './variables/variables-manager';
+
+interface DocumentLine {
+  line: number;
+  text: string;
+}
+
+interface LineExtraction {
+  line: number;
+  colors: IColor[];
+}
+
+const flattenLineExtractionsFlatten = arr => arr.reduce((a, b) => a.concat(Array.isArray(b) ? flattenLineExtractionsFlatten(b) : b), []).filter(_ => _.colors.length !== 0);
 
 const WHITE = '#FFFFFF',
       BLACK = '#000000';
@@ -205,4 +216,4 @@ function executeHSLProperFormula(tmp_1: number, tmp_2: number, value: number): n
 
 export default ColorUtil;
 
-export { IDecoration, convertHslaToRgba, colorLuminance, convertRgbaToHsla, generateOptimalTextColor };
+export { IDecoration, convertHslaToRgba, colorLuminance, convertRgbaToHsla, generateOptimalTextColor, flattenLineExtractionsFlatten, LineExtraction, DocumentLine };

--- a/src/lib/colors/color-extractor.ts
+++ b/src/lib/colors/color-extractor.ts
@@ -1,12 +1,17 @@
 import { IColor } from './color';
+import { DocumentLine } from '../variables/variables-manager';
 
 export interface IColorExtractor {
   name: string;
-  extractColors(text: string): Promise < IColor[] >;
+  extractColors(fileLines: DocumentLine[]): Promise < LineExtraction[] >;
   extractColor(text: string): IColor;
 }
+export interface LineExtraction {
+  line: number;
+  colors: IColor[];
+}
 
-const flatten = arr => arr.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []);
+const flatten = arr => arr.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []).filter(_ => _.colors.length !== 0);
 
 class ColorExtractor {
   public extractors: IColorExtractor[];
@@ -30,8 +35,9 @@ class ColorExtractor {
     }
     return this.extractors.find(_ => _.name === extractor);
   }
-  public async extract(text: string): Promise < IColor[] > {
-    const colors = await Promise.all(this.extractors.map(extractor => extractor.extractColors(text)));
+  public async extract(fileLines: DocumentLine[]): Promise < LineExtraction[] > {
+    const colors = await Promise.all(this.extractors.map(extractor => extractor.extractColors(fileLines)));
+
     return flatten(colors);
   }
   public extractOneColor(text: string): IColor {

--- a/src/lib/colors/color-extractor.ts
+++ b/src/lib/colors/color-extractor.ts
@@ -37,8 +37,7 @@ class ColorExtractor {
   }
   public async extract(fileLines: DocumentLine[]): Promise < LineExtraction[] > {
     const colors = await Promise.all(this.extractors.map(extractor => extractor.extractColors(fileLines)));
-
-    return flatten(colors);
+    return flatten(colors); // should regroup per lines?
   }
   public extractOneColor(text: string): IColor {
     let colors = this.extractors.map(extractor => extractor.extractColor(text));

--- a/src/lib/colors/color-extractor.ts
+++ b/src/lib/colors/color-extractor.ts
@@ -1,18 +1,11 @@
 import { IColor } from './color';
-import { DocumentLine } from '../variables/variables-manager';
+import { LineExtraction, DocumentLine, flattenLineExtractionsFlatten } from '../color-util';
 
 export interface IColorExtractor {
   name: string;
   extractColors(fileLines: DocumentLine[]): Promise < LineExtraction[] >;
   extractColor(text: string): IColor;
 }
-export interface LineExtraction {
-  line: number;
-  colors: IColor[];
-}
-
-const flatten = arr => arr.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []).filter(_ => _.colors.length !== 0);
-
 class ColorExtractor {
   public extractors: IColorExtractor[];
   constructor() {
@@ -37,7 +30,7 @@ class ColorExtractor {
   }
   public async extract(fileLines: DocumentLine[]): Promise < LineExtraction[] > {
     const colors = await Promise.all(this.extractors.map(extractor => extractor.extractColors(fileLines)));
-    return flatten(colors); // should regroup per lines?
+    return flattenLineExtractionsFlatten(colors); // should regroup per lines?
   }
   public extractOneColor(text: string): IColor {
     let colors = this.extractors.map(extractor => extractor.extractColor(text));

--- a/src/lib/colors/extractors/browser-extractor.ts
+++ b/src/lib/colors/extractors/browser-extractor.ts
@@ -1,5 +1,6 @@
 import Color from './../color';
-import ColorExtractor, { IColorExtractor } from '../color-extractor';
+import ColorExtractor, { IColorExtractor, LineExtraction } from '../color-extractor';
+import { DocumentLine } from '../../variables/variables-manager';
 
 export const COLORS = Object({
     'aliceblue': {
@@ -753,7 +754,16 @@ export const REGEXP_ONE = (() => RegExp(`^(?:^|,|\s|\\(|:)(${REGEXP_BASE})(?:$|,
 class BrowsersColorExtractor implements IColorExtractor {
   public name: string = 'BROWSERS_COLORS_EXTRACTOR';
 
-  public async extractColors(text: string): Promise<Color []> {
+  public async extractColors(fileLines: DocumentLine[]): Promise < LineExtraction[] > {
+    const colors: LineExtraction[] = fileLines.map(({line, text}) => {
+      return {
+        line,
+        colors: this.__extractColors(text)
+      };
+    });
+    return colors;
+  }
+  public __extractColors(text: string): Color[] {
     let match = null;
     let colors: Color[] = [];
     let position = 0;
@@ -774,5 +784,6 @@ class BrowsersColorExtractor implements IColorExtractor {
     return null;
   }
 }
+
 ColorExtractor.registerExtractor(new BrowsersColorExtractor());
 export default BrowsersColorExtractor;

--- a/src/lib/colors/extractors/browser-extractor.ts
+++ b/src/lib/colors/extractors/browser-extractor.ts
@@ -1,6 +1,6 @@
 import Color from './../color';
-import ColorExtractor, { IColorExtractor, LineExtraction } from '../color-extractor';
-import { DocumentLine } from '../../variables/variables-manager';
+import ColorExtractor, { IColorExtractor } from '../color-extractor';
+import { LineExtraction, DocumentLine } from '../../color-util';
 
 export const COLORS = Object({
     'aliceblue': {
@@ -755,25 +755,18 @@ class BrowsersColorExtractor implements IColorExtractor {
   public name: string = 'BROWSERS_COLORS_EXTRACTOR';
 
   public async extractColors(fileLines: DocumentLine[]): Promise < LineExtraction[] > {
-    const colors: LineExtraction[] = fileLines.map(({line, text}) => {
-      return {
-        line,
-        colors: this.__extractColors(text)
-      };
+    return fileLines.map(({line, text}) => {
+      let match = null;
+      let colors: Color[] = [];
+      let position = 0;
+      while ((match = text.match(REGEXP)) !== null) {
+        position += match.index + 1;
+        colors.push(new Color(match[1], position, 1, COLORS[match[1]].rgb));
+        text = text.slice(match.index + 1 + match[1].length);
+        position += match[1].length;
+      }
+      return {line, colors};
     });
-    return colors;
-  }
-  public __extractColors(text: string): Color[] {
-    let match = null;
-    let colors: Color[] = [];
-    let position = 0;
-    while ((match = text.match(REGEXP)) !== null) {
-      position += match.index + 1;
-      colors.push(new Color(match[1], position, 1, COLORS[match[1]].rgb));
-      text = text.slice(match.index + 1 + match[1].length);
-      position += match[1].length;
-    }
-    return colors;
   }
 
   public extractColor(text: string): Color {

--- a/src/lib/colors/extractors/hexa-extractor.ts
+++ b/src/lib/colors/extractors/hexa-extractor.ts
@@ -1,7 +1,7 @@
 import Color from './../color';
-import ColorExtractor, { IColorExtractor, LineExtraction } from '../color-extractor';
+import ColorExtractor, { IColorExtractor } from '../color-extractor';
 import color from './../color';
-import { DocumentLine } from '../../variables/variables-manager';
+import { LineExtraction, DocumentLine } from '../../color-util';
 
 export const REGEXP = /(#[\da-f]{3,4}|#[\da-f]{6}|#[\da-f]{8})(?:$|"|'|,| |;|\)|\r|\n)/gi;
 export const REGEXP_ONE = /^(#[\da-f]{3,4}|#[\da-f]{6}|#[\da-f]{8})(?:$|"|'|,| |;|\)|\r|\n)/i;
@@ -30,22 +30,18 @@ class HexaColorExtractor implements IColorExtractor {
     return 1;
   }
   public async extractColors(fileLines: DocumentLine[]): Promise < LineExtraction[] > {
-    const colors: LineExtraction[] = fileLines.map(({line, text}) => {
+    return fileLines.map(({line, text}) => {
+      let match = null;
+      let colors: Color[] = [];
+
+      while ((match = REGEXP.exec(text)) !== null) {
+        colors.push(new Color(match[1], match.index, this.extractAlphaValue(match[1]), this.extractRGBValue(match[1])));
+      }
       return {
         line,
-        colors: this.__extractColors(text)
+        colors
       };
     });
-    return colors;
-  }
-  public __extractColors(text: string): Color[] {
-    let match = null;
-    let colors: Color[] = [];
-
-    while ((match = REGEXP.exec(text)) !== null) {
-      colors.push(new Color(match[1], match.index, this.extractAlphaValue(match[1]), this.extractRGBValue(match[1])));
-    }
-    return colors;
   }
   public extractColor(text: string, fileName = null): Color {
     let match: RegExpMatchArray = text.match(REGEXP_ONE);

--- a/src/lib/colors/extractors/hexa-extractor.ts
+++ b/src/lib/colors/extractors/hexa-extractor.ts
@@ -1,5 +1,7 @@
 import Color from './../color';
-import ColorExtractor, { IColorExtractor } from '../color-extractor';
+import ColorExtractor, { IColorExtractor, LineExtraction } from '../color-extractor';
+import color from './../color';
+import { DocumentLine } from '../../variables/variables-manager';
 
 export const REGEXP = /(#[\da-f]{3,4}|#[\da-f]{6}|#[\da-f]{8})(?:$|"|'|,| |;|\)|\r|\n)/gi;
 export const REGEXP_ONE = /^(#[\da-f]{3,4}|#[\da-f]{6}|#[\da-f]{8})(?:$|"|'|,| |;|\)|\r|\n)/i;
@@ -27,7 +29,16 @@ class HexaColorExtractor implements IColorExtractor {
     }
     return 1;
   }
-  public async extractColors(text: string): Promise < Color[] > {
+  public async extractColors(fileLines: DocumentLine[]): Promise < LineExtraction[] > {
+    const colors: LineExtraction[] = fileLines.map(({line, text}) => {
+      return {
+        line,
+        colors: this.__extractColors(text)
+      };
+    });
+    return colors;
+  }
+  public __extractColors(text: string): Color[] {
     let match = null;
     let colors: Color[] = [];
 

--- a/src/lib/colors/extractors/hsl-extractor.ts
+++ b/src/lib/colors/extractors/hsl-extractor.ts
@@ -1,6 +1,8 @@
 import Color from './../color';
-import ColorExtractor, { IColorExtractor } from '../color-extractor';
+import ColorExtractor, { IColorExtractor, LineExtraction } from '../color-extractor';
 import { convertHslaToRgba } from '../../color-util';
+import { DocumentLine } from '../../variables/variables-manager';
+
 
 export const REGEXP = /((?:hsl\(\d*\s*,\s*\d{1,3}%\s*,\s*\d{1,3}%\))|(?:hsla\(\d*\s*,\s*(?:\d{1,3}%\s*,\s*){2}(?:[0-1]|1\.0|[0](?:\.\d+){0,1}|(?:\.\d+))\)))(?:$|"|'|,| |;|\)|\r|\n)/gi;
 export const REGEXP_ONE = /^((?:hsl\(\d*\s*,\s*\d{1,3}%\s*,\s*\d{1,3}%\))|(?:hsla\(\d*\s*,\s*(?:\d{1,3}%\s*,\s*){2}(?:[0-1]|1\.0|[0](?:\.\d+){0,1}|(?:\.\d+))\)))(?:$|"|'|,| |;|\)|\r|\n)/i;
@@ -29,7 +31,17 @@ class HSLColorExtractor implements IColorExtractor {
     return [h, s, l, a];
   }
 
-  public async extractColors(text: string): Promise < Color[] >  {
+  public async extractColors(fileLines: DocumentLine[]): Promise < LineExtraction[] > {
+    const colors: LineExtraction[] = fileLines.map(({line, text}) => {
+      return {
+        line,
+        colors: this.__extractColors(text)
+      };
+    });
+    return colors;
+  }
+
+  public __extractColors(text: string): Color[]  {
     let match = null;
     let colors: Color[] = [];
     while ((match = REGEXP.exec(text)) !== null) {
@@ -51,6 +63,6 @@ class HSLColorExtractor implements IColorExtractor {
     return null;
   }
 }
-ColorExtractor.registerExtractor(new HSLColorExtractor());
 
+ColorExtractor.registerExtractor(new HSLColorExtractor());
 export default HSLColorExtractor;

--- a/src/lib/colors/extractors/hsl-extractor.ts
+++ b/src/lib/colors/extractors/hsl-extractor.ts
@@ -1,7 +1,7 @@
 import Color from './../color';
-import ColorExtractor, { IColorExtractor, LineExtraction } from '../color-extractor';
+import ColorExtractor, { IColorExtractor } from '../color-extractor';
 import { convertHslaToRgba } from '../../color-util';
-import { DocumentLine } from '../../variables/variables-manager';
+import { LineExtraction, DocumentLine } from '../../color-util';
 
 
 export const REGEXP = /((?:hsl\(\d*\s*,\s*\d{1,3}%\s*,\s*\d{1,3}%\))|(?:hsla\(\d*\s*,\s*(?:\d{1,3}%\s*,\s*){2}(?:[0-1]|1\.0|[0](?:\.\d+){0,1}|(?:\.\d+))\)))(?:$|"|'|,| |;|\)|\r|\n)/gi;
@@ -32,25 +32,20 @@ class HSLColorExtractor implements IColorExtractor {
   }
 
   public async extractColors(fileLines: DocumentLine[]): Promise < LineExtraction[] > {
-    const colors: LineExtraction[] = fileLines.map(({line, text}) => {
+    return fileLines.map(({line, text}) => {
+      let match = null;
+      let colors: Color[] = [];
+      while ((match = REGEXP.exec(text)) !== null) {
+        const color = this.generateColorFromMatch(match);
+        if (color !== null) {
+          colors.push(color);
+        }
+      }
       return {
         line,
-        colors: this.__extractColors(text)
+        colors
       };
     });
-    return colors;
-  }
-
-  public __extractColors(text: string): Color[]  {
-    let match = null;
-    let colors: Color[] = [];
-    while ((match = REGEXP.exec(text)) !== null) {
-      const color = this.generateColorFromMatch(match);
-      if (color !== null) {
-        colors.push(color);
-      }
-    }
-    return colors;
   }
   public extractColor(text: string): Color {
     let match: RegExpMatchArray = text.match(REGEXP_ONE);

--- a/src/lib/colors/extractors/rgb-extractor.ts
+++ b/src/lib/colors/extractors/rgb-extractor.ts
@@ -1,5 +1,6 @@
-import ColorExtractor, { IColorExtractor } from '../color-extractor';
+import ColorExtractor, { IColorExtractor, LineExtraction } from '../color-extractor';
 import Color from '../color';
+import { DocumentLine } from '../../variables/variables-manager';
 
 export const REGEXP = /((?:rgb\((?:\d{1,3}\s*,\s*){2}\d{1,3}\))|(?:rgba\((?:\d{1,3}\s*,\s*){3}(?:[0-1]|1\.0|[0](?:\.\d+){0,1}|(?:\.\d+))\)))(?:$|"|'|,| |;|\)|\r|\n)/gi;
 export const REGEXP_ONE = /^((?:rgb\((?:\d{1,3}\s*,\s*){2}\d{1,3}\))|(?:rgba\((?:\d{1,3}\s*,\s*){3}(?:[0-1]|1\.0|[0](?:\.\d+){0,1}|(?:\.\d+))\)))(?:$|"|'|,| |;|\)|\r|\n)/i;
@@ -11,8 +12,16 @@ class RgbExtractor implements IColorExtractor {
     let rgba =  value.replace(/rgb(a){0,1}\(/, '').replace(/\)/, '').split(/,/gi).map(c => parseFloat(c));
     return rgba.slice(0, 3);
   }
-
-  public async extractColors(text: string): Promise<Color[]> {
+  public async extractColors(fileLines: DocumentLine[]): Promise < LineExtraction[] > {
+    const colors: LineExtraction[] = fileLines.map(({line, text}) => {
+      return {
+        line,
+        colors: this.__extractColors(text)
+      };
+    });
+    return colors;
+  }
+  public __extractColors(text: string): Color[] {
     let match = null;
     let colors: Color[] = [];
     // Get rgb "like" colors
@@ -37,5 +46,6 @@ class RgbExtractor implements IColorExtractor {
     return null;
   }
 }
+
 ColorExtractor.registerExtractor(new RgbExtractor());
 export default RgbExtractor;

--- a/src/lib/colors/extractors/rgb-extractor.ts
+++ b/src/lib/colors/extractors/rgb-extractor.ts
@@ -1,6 +1,6 @@
-import ColorExtractor, { IColorExtractor, LineExtraction } from '../color-extractor';
+import ColorExtractor, { IColorExtractor } from '../color-extractor';
 import Color from '../color';
-import { DocumentLine } from '../../variables/variables-manager';
+import { LineExtraction, DocumentLine } from '../../color-util';
 
 export const REGEXP = /((?:rgb\((?:\d{1,3}\s*,\s*){2}\d{1,3}\))|(?:rgba\((?:\d{1,3}\s*,\s*){3}(?:[0-1]|1\.0|[0](?:\.\d+){0,1}|(?:\.\d+))\)))(?:$|"|'|,| |;|\)|\r|\n)/gi;
 export const REGEXP_ONE = /^((?:rgb\((?:\d{1,3}\s*,\s*){2}\d{1,3}\))|(?:rgba\((?:\d{1,3}\s*,\s*){3}(?:[0-1]|1\.0|[0](?:\.\d+){0,1}|(?:\.\d+))\)))(?:$|"|'|,| |;|\)|\r|\n)/i;
@@ -13,26 +13,22 @@ class RgbExtractor implements IColorExtractor {
     return rgba.slice(0, 3);
   }
   public async extractColors(fileLines: DocumentLine[]): Promise < LineExtraction[] > {
-    const colors: LineExtraction[] = fileLines.map(({line, text}) => {
+    return fileLines.map(({line, text}) => {
+      let match = null;
+      let colors: Color[] = [];
+      // Get rgb "like" colors
+      while ((match = REGEXP.exec(text)) !== null) {
+        let rgba = match[1].replace(/rgb(a){0,1}\(/, '').replace(/\)/, '').split(/,/gi).map(c => parseFloat(c));
+        // Check if it's a valid rgb(a) color
+        if (rgba.slice(0, 3).every(c => c <= 255)) {
+          colors.push(new Color(match[1], match.index, 1, this.extractRGBAValue(match[1])));
+        }
+      }
       return {
         line,
-        colors: this.__extractColors(text)
+        colors
       };
     });
-    return colors;
-  }
-  public __extractColors(text: string): Color[] {
-    let match = null;
-    let colors: Color[] = [];
-    // Get rgb "like" colors
-    while ((match = REGEXP.exec(text)) !== null) {
-      let rgba = match[1].replace(/rgb(a){0,1}\(/, '').replace(/\)/, '').split(/,/gi).map(c => parseFloat(c));
-      // Check if it's a valid rgb(a) color
-      if (rgba.slice(0, 3).every(c => c <= 255)) {
-        colors.push(new Color(match[1], match.index, 1, this.extractRGBAValue(match[1])));
-      }
-    }
-    return colors;
   }
   public extractColor(text: string): Color {
     let match: RegExpMatchArray = text.match(REGEXP_ONE);

--- a/src/lib/variables/variable-decoration.ts
+++ b/src/lib/variables/variable-decoration.ts
@@ -5,7 +5,6 @@ import {
   Position,
   window
 } from 'vscode';
-
 import { generateOptimalTextColor } from '../color-util';
 import Color from '../colors/color';
 import Variable from './variable';

--- a/src/lib/variables/variables-extractor.ts
+++ b/src/lib/variables/variables-extractor.ts
@@ -1,8 +1,8 @@
 import Variable from './variable';
 import Color from '../colors/color';
-import ColorExtractor, { LineExtraction } from '../colors/color-extractor';
+import ColorExtractor from '../colors/color-extractor';
 import { dirname } from 'path';
-import { DocumentLine } from './variables-manager';
+import { DocumentLine, LineExtraction, flattenLineExtractionsFlatten } from '../color-util';
 
 // stylus no prefix needed and = instead of :
 export const DECLARATION_REGEXP = /(?:(?:((?:\$|@|--)(?:[a-z]+[\-_a-z\d]*)\s*):)|(\w(?:\w|-)*)\s*=)(?:$|"|'|,| |;|\)|\r|\n)/gi;
@@ -11,8 +11,6 @@ export const DECLARATION_REGEXP = /(?:(?:((?:\$|@|--)(?:[a-z]+[\-_a-z\d]*)\s*):)
 export const REGEXP = /(?:((?:(?:@|\s|\$)(?:[a-z]+[\-_a-z\d]*)+))|(var\((--\w+(?:-|\w)*)\)))(?:$|"|'|,| |;|\)|\r|\n)(?!\s*(?:=|:))/gi;
 
 export const REGEXP_ONE = /^(?:((?:(?:\$|@)(?:[a-z]+[\-_a-z\d]*)+))|(?:var\((--\w+(?:-|\w)*))\))(?:$|"|'|,| |;|\)|\r|\n)(?!\s*(?:=|:))/gi;
-
-const flatten = arr => arr.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []).filter(_ => _.colors.length !== 0);
 
 class VariablesExtractor {
 
@@ -115,7 +113,7 @@ class VariablesExtractor {
         colors: this.__extractVariables(text, fileName)
       };
     });
-    return flatten(variables);
+    return flattenLineExtractionsFlatten(variables);
   }
   public __extractVariables(text: string, fileName: string): Variable[] {
     let match = null;

--- a/src/lib/variables/variables-extractor.ts
+++ b/src/lib/variables/variables-extractor.ts
@@ -1,7 +1,9 @@
 import Variable from './variable';
 import Color from '../colors/color';
-import ColorExtractor from '../colors/color-extractor';
+import ColorExtractor, { LineExtraction } from '../colors/color-extractor';
 import { dirname } from 'path';
+import { DocumentLine } from './variables-manager';
+
 // stylus no prefix needed and = instead of :
 export const DECLARATION_REGEXP = /(?:(?:((?:\$|@|--)(?:[a-z]+[\-_a-z\d]*)\s*):)|(\w(?:\w|-)*)\s*=)(?:$|"|'|,| |;|\)|\r|\n)/gi;
 //  \b allow to catch stylus variables names
@@ -9,6 +11,8 @@ export const DECLARATION_REGEXP = /(?:(?:((?:\$|@|--)(?:[a-z]+[\-_a-z\d]*)\s*):)
 export const REGEXP = /(?:((?:(?:@|\s|\$)(?:[a-z]+[\-_a-z\d]*)+))|(var\((--\w+(?:-|\w)*)\)))(?:$|"|'|,| |;|\)|\r|\n)(?!\s*(?:=|:))/gi;
 
 export const REGEXP_ONE = /^(?:((?:(?:\$|@)(?:[a-z]+[\-_a-z\d]*)+))|(?:var\((--\w+(?:-|\w)*))\))(?:$|"|'|,| |;|\)|\r|\n)(?!\s*(?:=|:))/gi;
+
+const flatten = arr => arr.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), []).filter(_ => _.colors.length !== 0);
 
 class VariablesExtractor {
 
@@ -103,7 +107,17 @@ class VariablesExtractor {
     }
   }
 
-  public async extractVariables(text: string, fileName: string): Promise<Variable[]> {
+  public async extractVariables(fileName: string, fileLines: DocumentLine[]): Promise<LineExtraction[]> {
+
+    const variables = fileLines.map(({line, text}) => {
+      return {
+        line,
+        colors: this.__extractVariables(text, fileName)
+      };
+    });
+    return flatten(variables);
+  }
+  public __extractVariables(text: string, fileName: string): Variable[] {
     let match = null;
     let colors: Variable[] = [];
     while ((match = REGEXP.exec(text)) !== null) {
@@ -144,8 +158,10 @@ class VariablesExtractor {
     }
     return null;
   }
-
-  public async extractDeclarations(fileName: string, text: string, line: number): Promise<Map<string, Variable[]>> {
+  public async extractDeclarations(fileName: string, fileLines: DocumentLine[]): Promise<Map<string, Variable[]>> {
+    return fileLines.map(({text, line}) => this.__extractDeclarations(fileName, text, line)).pop();
+  }
+  public __extractDeclarations(fileName: string, text: string, line: number): Map<string, Variable[]> {
     let match = null;
     while ((match = DECLARATION_REGEXP.exec(text)) !== null) {
       const varName = (match[1] || match[2]).trim();

--- a/src/lib/variables/variables-manager.ts
+++ b/src/lib/variables/variables-manager.ts
@@ -3,15 +3,10 @@ import VariableDecoration from './variable-decoration';
 import VariablesExtractor from './variables-extractor';
 import { workspace, window, StatusBarAlignment, StatusBarItem, Uri, TextDocument } from 'vscode';
 import { canColorize } from '../../extension';
-import { LineExtraction } from '../colors/color-extractor';
+import { DocumentLine, LineExtraction } from '../color-util';
 
 const INCLUDE_PATTERN = '{**/*.css,**/*.sass,**/*.scss,**/*.less,**/*.pcss,**/*.sss,**/*.stylus,**/*.styl}';
 const EXCLUDE_PATTERN = '{**/.git,**/.svn,**/.hg,**/CVS,**/.DS_Store,**/.git,**/node_modules,**/bower_components,**/tmp,**/dist,**/tests}';
-
-interface DocumentLine {
-  line: number;
-  text: string;
-}
 
 class VariablesManager {
 
@@ -73,4 +68,3 @@ class VariablesManager {
 }
 
 export default VariablesManager;
-export { DocumentLine };

--- a/src/lib/variables/variables-manager.ts
+++ b/src/lib/variables/variables-manager.ts
@@ -3,6 +3,7 @@ import VariableDecoration from './variable-decoration';
 import VariablesExtractor from './variables-extractor';
 import { workspace, window, StatusBarAlignment, StatusBarItem, Uri, TextDocument } from 'vscode';
 import { canColorize } from '../../extension';
+import { LineExtraction } from '../colors/color-extractor';
 
 const INCLUDE_PATTERN = '{**/*.css,**/*.sass,**/*.scss,**/*.less,**/*.pcss,**/*.sss,**/*.stylus,**/*.styl}';
 const EXCLUDE_PATTERN = '{**/.git,**/.svn,**/.hg,**/CVS,**/.DS_Store,**/.git,**/node_modules,**/bower_components,**/tmp,**/dist,**/tests}';
@@ -23,8 +24,8 @@ class VariablesManager {
       const files: Uri[] = await workspace.findFiles(INCLUDE_PATTERN, EXCLUDE_PATTERN);
       statusBar.text = `Found ${files.length} files`;
 
-    let variables: Map<String, Variable[]> = (await Promise.all(this.extractFilesVariable(files))).pop(); // pop ><
-    statusBar.text = `Found ${variables.size} variables`;
+      let variables: Map<String, Variable[]> = (await Promise.all(this.extractFilesVariable(files))).pop(); // pop ><
+      statusBar.text = `Found ${variables.size} variables`;
     } catch (error) {
       statusBar.text = 'Variables extraction fail';
     }
@@ -47,17 +48,17 @@ class VariablesManager {
     return files.map(async(file) => {
       const document: TextDocument =  await workspace.openTextDocument(file.path);
       const content: DocumentLine[] = this.getFileContent(document);
-      const variables = await Promise.all(content.map(line => this.findVariablesDeclarations(document.fileName, line.text, line.line)));
-      return variables[variables.length - 1 ];
+      const variables = await this.findVariablesDeclarations(document.fileName, content);
+      return variables;
     });
   }
 
-  public static findVariablesDeclarations(fileName, text, line): Promise <Map<String, Variable[]>> {
-    return VariablesExtractor.extractDeclarations(fileName, text, line);
+  public static findVariablesDeclarations(fileName, fileLines: DocumentLine[]): Promise <Map<String, Variable[]>> {
+    return VariablesExtractor.extractDeclarations(fileName, fileLines);
   }
 
-  public static findVariables(fileName, text): Promise <Variable[]> {
-    return VariablesExtractor.extractVariables(fileName, text);
+  public static findVariables(fileName, fileLines: DocumentLine[]): Promise <LineExtraction[]> {
+    return VariablesExtractor.extractVariables(fileName, fileLines);
   }
 
   public static generateDecoration(Variable: Variable): VariableDecoration {
@@ -72,3 +73,4 @@ class VariablesManager {
 }
 
 export default VariablesManager;
+export { DocumentLine };

--- a/test/color-util.test.ts
+++ b/test/color-util.test.ts
@@ -7,12 +7,12 @@ import Color from '../src/lib/colors/color';
 
 describe('Test utility fonction', () => {
   it('Should not extract invalid colors from a text', async () => {
-    const colors = await ColorUtil.findColors('#ffg, rgb(323,123,123)');
-    assert.equal(0, colors.length, 'Should have found 0 colors');
+    const colors = await ColorUtil.findColors([{line: 1, text: '#ffg, rgb(323,123,123)'}]);
+    assert.equal(0, colors.reduce((acc, cv) => acc.concat(cv.colors), []).length, 'Should have found 0 colors');
   });
   it('Should extract Colors from a text', async () => {
-    const colors = await ColorUtil.findColors('#fff, rgb(123,123,123), #dccdcd, linear-gradient(to bottom right, #fff, #ccc), white, hsl(123,10%,1%)');
-    assert.equal(7, colors.length, 'Should have found 7 colors');
+    const colors = await ColorUtil.findColors([{line: 1, text: '#fff, rgb(123,123,123), #dccdcd, linear-gradient(to bottom right, #fff, #ccc), white, hsl(123,10%,1%)'}]);
+    assert.equal(7, colors.reduce((acc, cv) => acc.concat(cv.colors), []).length, 'Should have found 7 colors');
   });
   it('Should return the color luminance', () => {
     assert.equal(colorLuminance(new Color('#fff', 0, 1, [255, 255, 255])), 1, 'Should be "1" for #fff');


### PR DESCRIPTION
Stop extracting lines per lines with a Promise encapsulation around.
Now send the whole document to the extractors.

Before colorize needed almost 6s to extract colors in a file with 2000 lines, it only takes 200ms now.
🎉 🎉 🎉 