### PR TITLE
Add colorize.browser_color_names setting, reload config when changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,10 @@ These can be set in user preferences `(cmd+,)` or workspace settings `(.vscode/s
             "svg"
     ],
     "colorize.files_extensions": [],
-    "colorire.hide_current_line_decorations": true
+    "colorize.hide_current_line_decorations": true,
+    "colorize.browser_color_names": true
 }
 ```
-
-⚠️ Changes to any of this settings will require a VSCode restart ️️️️⚠️
 
 ### colorize.languages _ARRAY_
 
@@ -91,6 +90,11 @@ For example if you want to colorize `.diff` files:
 ### colorize.hide_current_line_decorations _BOOLEAN_ _default: true_
 
 By default decorations for the current line are hidden. Set this setting to false to deactivate this behavior.
+
+### colorize.browser_color_names _BOOLEAN_ _default: true_
+
+By default the color names recognized by most browsers within HTML and CSS documents will be colorized.
+Set this property to false to not colorize these names.
 
 ### colorize.activate_variables_support_beta _BOOLEAN_ _default: false_
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,13 @@
           "default": false,
           "type": "boolean",
           "description": "Activate the variables extractions/decorations feature (beta)"
-        }
+        },
+				"colorize.browser_color_names": {
+					"title": "Colorize browser color names",
+					"default": true,
+					"type": "boolean",
+					"description": "Colorize the names of HTML and CSS colors"
+				}
       }
     }
   },

--- a/src/lib/cache-manager.ts
+++ b/src/lib/cache-manager.ts
@@ -3,7 +3,7 @@ import { TextDocument } from 'vscode';
 
 class CacheManager {
   private _dirtyCache: Map < string, Map < number, IDecoration[] > >;
-  private _decorationsCache: Map < string, Map < number, IDecoration[] > > = new Map();
+  private _decorationsCache: Map < string, Map < number, IDecoration[] > >;
 
   constructor() {
     this._dirtyCache = new Map();

--- a/src/lib/colors/strategies/browser-strategy.ts
+++ b/src/lib/colors/strategies/browser-strategy.ts
@@ -1,6 +1,7 @@
-import Color from './../color';
+import Color from '../color';
 import ColorExtractor, { IColorStrategy } from '../color-extractor';
 import { LineExtraction, DocumentLine } from '../../color-util';
+import { isBrowserColorNamesEnabled } from '../../../extension';
 
 export const COLORS = Object({
     'aliceblue': {
@@ -759,18 +760,23 @@ class BrowsersColorExtractor implements IColorStrategy {
       let match = null;
       let colors: Color[] = [];
       let position = 0;
-      while ((match = text.match(REGEXP)) !== null) {
-        position += match.index + 1;
-        const browserColor: string = match[1];
-        colors.push(new Color(match[1], position, COLORS[browserColor.toLowerCase()].rgb));
-        text = text.slice(match.index + 1 + match[1].length);
-        position += match[1].length;
+      if (isBrowserColorNamesEnabled()) {
+        while ((match = text.match(REGEXP)) !== null) {
+          position += match.index + 1;
+          const browserColor: string = match[1];
+          colors.push(new Color(match[1], position, COLORS[browserColor.toLowerCase()].rgb));
+          text = text.slice(match.index + 1 + match[1].length);
+          position += match[1].length;
+        }
       }
       return {line, colors};
     });
   }
 
   public extractColor(text: string): Color {
+    if (!isBrowserColorNamesEnabled()) {
+      return null;
+    }
     let match = text.match(REGEXP_ONE);
     if (match) {
         const browserColor: string = match[1];

--- a/todo.todo
+++ b/todo.todo
@@ -1,4 +1,3 @@
-- check ConfigurationChangeEvent
 - check :
   _Tasks
   Schema improvements


### PR DESCRIPTION
There are two features included with this PR.

1. colorize.browser_color_names setting to turn off colorization of browser color names (default is true, meaning color names are colorized by default)
2. reload configuration changes automatically without having to restart (applies to all config settings except  colorize.activate_variables_support_beta)

Also included is a minor bug fix in CacheManager to avoid initializing _decorationsCache twice.