### PR TITLE
Enable disable colorization for colors/variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,13 +56,14 @@
           "description": "Languages that should be colorized"
         },
         "colorize.files_extensions": {
-          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$schema": "http://json-schema.org/draft-07/schema#",
           "default": [],
           "title": "Colorize files with these extensions",
           "type": "array",
           "items": {
             "type": "string",
             "pattern": "\\.\\w+$",
+            "uniqueItems": true,
             "description": "You should enter a valid file extension"
           },
           "description": "Specified files extension that should be colorized"

--- a/package.json
+++ b/package.json
@@ -78,6 +78,28 @@
           "default": false,
           "type": "boolean",
           "description": "Activate the variables extractions/decorations feature (beta)"
+        },
+        "colorize.enabled_variables_extractors": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "default": [
+            "CSS",
+            "SASS",
+            "LESS",
+            "STYLUS"
+          ],
+          "items": {
+            "enum": [
+              "CSS",
+              "SASS",
+              "LESS",
+              "STYLUS"
+            ],
+            "description": "You should enter a valid extractor",
+            "uniqueItems": true
+          },
+          "title": "Extract these type of variables",
+          "type": "array",
+          "description": "Specified the type of variables that should be extracted"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -100,6 +100,28 @@
           "title": "Extract these type of variables",
           "type": "array",
           "description": "Specified the type of variables that should be extracted"
+        },
+        "colorize.enabled_colors_extractors": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "default": [
+            "BROWSERS_COLORS",
+            "HEXA",
+            "RGB",
+            "HSL"
+          ],
+          "items": {
+            "enum": [
+              "BROWSERS_COLORS",
+              "HEXA",
+              "RGB",
+              "HSL"
+            ],
+            "description": "You should enter a valid extractor",
+            "uniqueItems": true
+          },
+          "title": "Colorize these type of color",
+          "type": "array",
+          "description": "Specified the type of color that should be colorized"
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,8 @@ let config = {
   languages: null,
   filesExtensions: null,
   isVariablesEnable: false,
-  isHideCurrentLineDecorations: true
+  isHideCurrentLineDecorations: true,
+  enabledVariablesExtractors: []
 };
 
 interface ColorizeContext {
@@ -445,6 +446,7 @@ function readConfiguration() {
   config.filesExtensions = configuration.get('files_extensions', []).map(ext => RegExp(`\\${ext}$`));
   config.isVariablesEnable = configuration.get('activate_variables_support_beta');
   config.isHideCurrentLineDecorations = configuration.get('hide_current_line_decorations');
+  config.enabledVariablesExtractors = configuration.get('enabled_variables_extractors');
 }
 
 function colorizeVisibleTextEditors() {

--- a/src/lib/color-util.ts
+++ b/src/lib/color-util.ts
@@ -82,6 +82,10 @@ class ColorUtil {
     return ColorExtractor.extract(fileContent);
   }
 
+  public static setupColorsExtractors(extractors: string[]) {
+    ColorExtractor.enableStategies(extractors);
+  }
+
   public static generateDecoration(color: IColor): IDecoration {
     return new ColorDecoration(<Color>color);
   }

--- a/src/lib/colors/color-extractor.ts
+++ b/src/lib/colors/color-extractor.ts
@@ -7,14 +7,12 @@ export interface IColorStrategy extends IStrategy {
   extractColor(text: string): IColor;
 }
 class ColorExtractor extends Extractor {
-  public strategies: IColorStrategy[];
-
   public async extract(fileLines: DocumentLine[]): Promise < LineExtraction[] > {
-    const colors = await Promise.all(this.strategies.map(strategy => strategy.extractColors(fileLines)));
+    const colors = await Promise.all(this.enabledStrategies.map(strategy => (<IColorStrategy> strategy).extractColors(fileLines)));
     return flattenLineExtractionsFlatten(colors); // should regroup per lines?
   }
   public extractOneColor(text: string): IColor {
-    let colors = this.strategies.map(strategy => strategy.extractColor(text));
+    let colors = this.enabledStrategies.map(strategy => (<IColorStrategy> strategy).extractColor(text));
     return colors.find(color => color !== null);
   }
 }

--- a/src/lib/colors/strategies/browser-strategy.ts
+++ b/src/lib/colors/strategies/browser-strategy.ts
@@ -752,7 +752,7 @@ export const REGEXP = (() => RegExp(`(?:,| |\\(|:)(${REGEXP_BASE})(?:$|,| |;|\\)
 export const REGEXP_ONE = (() => RegExp(`^(?:^|,|\s|\\(|:)(${REGEXP_BASE})(?:$|,| |;|\\)|\\r|\\n)`, 'i'))();
 
 class BrowsersColorExtractor implements IColorStrategy {
-  public name: string = 'BROWSERS_COLORS_EXTRACTOR';
+  public name: string = 'BROWSERS_COLORS';
 
   public async extractColors(fileLines: DocumentLine[]): Promise < LineExtraction[] > {
     return fileLines.map(({line, text}) => {

--- a/src/lib/colors/strategies/hexa-strategy.ts
+++ b/src/lib/colors/strategies/hexa-strategy.ts
@@ -7,7 +7,7 @@ export const REGEXP = /((?:#|0x)[\da-f]{3,4}|(?:#|0x)[\da-f]{6}|(?:#|0x)[\da-f]{
 export const REGEXP_ONE = /^((?:#|0x)[\da-f]{3,4}|(?:#|0x)[\da-f]{6}|(?:#|0x)[\da-f]{8})(?:$|"|'|,| |;|\)|\r|\n)/i;
 
 class HexaColorExtractor implements IColorStrategy {
-  public name: string = 'HEXA_EXTRACTOR';
+  public name: string = 'HEXA';
 
   private extractRGBValue(value): number[] {
     let rgb: any = /#(.+)/gi.exec(value);

--- a/src/lib/colors/strategies/hsl-strategy.ts
+++ b/src/lib/colors/strategies/hsl-strategy.ts
@@ -8,7 +8,7 @@ export const REGEXP = /((?:hsl\(\d*\s*,\s*\d{1,3}%\s*,\s*\d{1,3}%\))|(?:hsla\(\d
 export const REGEXP_ONE = /^((?:hsl\(\d*\s*,\s*\d{1,3}%\s*,\s*\d{1,3}%\))|(?:hsla\(\d*\s*,\s*(?:\d{1,3}%\s*,\s*){2}(?:[0-1]|1\.0|[0](?:\.\d+){0,1}|(?:\.\d+))\)))(?:$|"|'|,| |;|\)|\r|\n)/i;
 
 class HSLColorExtractor implements IColorStrategy {
-  public name: string = 'HSL_EXTRACTOR';
+  public name: string = 'HSL';
 
   private generateColorFromMatch(match: RegExpMatchArray): Color {
     const [h, s, l, a] = this.extractHSLValue(match[1]);

--- a/src/lib/colors/strategies/rgb-strategy.ts
+++ b/src/lib/colors/strategies/rgb-strategy.ts
@@ -6,7 +6,7 @@ export const REGEXP = /((?:rgb\((?:\d{1,3}\s*,\s*){2}\d{1,3}\))|(?:rgba\((?:\d{1
 export const REGEXP_ONE = /^((?:rgb\((?:\d{1,3}\s*,\s*){2}\d{1,3}\))|(?:rgba\((?:\d{1,3}\s*,\s*){3}(?:[0-1]|1\.0|[0](?:\.\d+){0,1}|(?:\.\d+))\)))(?:$|"|'|,| |;|\)|\r|\n)/i;
 
 class RgbExtractor implements IColorStrategy {
-  public name: string = 'RGB_EXTRACTOR';
+  public name: string = 'RGB';
 
   private extractRGBAValue(value): number[] {
     let rgba =  value.replace(/rgb(a){0,1}\(/, '').replace(/\)/, '').split(/,/gi).map(c => parseFloat(c));

--- a/src/lib/editor-manager.ts
+++ b/src/lib/editor-manager.ts
@@ -21,7 +21,7 @@ class EditorManager {
       const line = tmp.value[0];
       const deco: IDecoration[] = tmp.value[1];
       if (skipLines.indexOf(line) === -1) {
-        this.decorateOneLine(editor, tmp.value[1], line);
+        this.decorateOneLine(editor, deco, line);
       }
       tmp = it.next();
     }
@@ -40,7 +40,7 @@ class EditorManager {
    */
   public static decorateOneLine(editor: TextEditor, decorations: IDecoration[], line: number) {
     decorations.forEach((decoration: IDecoration) => {
-      if (!(<VariableDecoration>decoration).disposed) {
+      if (!(<VariableDecoration>decoration).disposed && decoration.decoration) {
         editor.setDecorations(decoration.decoration, [decoration.generateRange(line)]);
       }
     });

--- a/src/lib/extractor-mixin.ts
+++ b/src/lib/extractor-mixin.ts
@@ -3,6 +3,17 @@ export interface IStrategy {
 }
 export class Extractor {
   public strategies: IStrategy[];
+  protected enabledStrategies: IStrategy[];
+
+  public enableStategies(strategiesToEnable: string[]) {
+    this.enabledStrategies = this.strategies.filter(strategy => {
+      if (strategiesToEnable.find(_ => _ === strategy.name)) {
+        let constructor: any = strategy.constructor;
+        return new constructor();
+      }
+    });
+  }
+
   constructor() {
     this.strategies = [];
   }

--- a/src/lib/variables/strategies/css-strategy.ts
+++ b/src/lib/variables/strategies/css-strategy.ts
@@ -11,7 +11,7 @@ export const REGEXP_ONE = new RegExp(`^(var\\((--(?:[a-z]+[\-_a-z\\d]*))\\))(?!:
 export const DECLARATION_REGEXP = new RegExp(`(?:(--(?:[a-z]+[\\-_a-z\\d]*)\\s*):)${REGEXP_END}`, 'gi');
 
 class CssExtractor implements IVariableStrategy {
-  public name: string = 'CSS_EXTRACTOR';
+  public name: string = 'CSS';
   private store: VariablesStore = new VariablesStore();
 
   public async extractDeclarations(fileName: string, fileLines: DocumentLine[]): Promise<number> {

--- a/src/lib/variables/strategies/less-strategy.ts
+++ b/src/lib/variables/strategies/less-strategy.ts
@@ -12,7 +12,7 @@ export const REGEXP_ONE = new RegExp(`^(@(?:[a-z]+[\\-_a-z\\d]*)(?!:))${REGEXP_E
 export const DECLARATION_REGEXP = new RegExp(`(?:(@(?:[a-z]+[\\-_a-z\\d]*)\\s*):)${REGEXP_END}`, 'gi');
 
 class LessExtractor implements IVariableStrategy {
-  name: string = 'LESS_EXTRACTOR';
+  name: string = 'LESS';
   private store: VariablesStore = new VariablesStore();
 
   public async extractDeclarations(fileName: string, fileLines: DocumentLine[]): Promise<number> {

--- a/src/lib/variables/strategies/sass-strategy.ts
+++ b/src/lib/variables/strategies/sass-strategy.ts
@@ -12,7 +12,7 @@ export const REGEXP_ONE = new RegExp(`^(\\$(?:[_a-z]+[\\-_a-z\\d]*)(?!:))${REGEX
 export const DECLARATION_REGEXP = new RegExp(`(?:(\\$(?:[_a-z]+[\\-_a-z\\d]*)\\s*):)${REGEXP_END}`, 'gi');
 
 class SassExtractor implements IVariableStrategy {
-  name: string = 'SASS_EXTRACTOR';
+  name: string = 'SASS';
   private store: VariablesStore = new VariablesStore();
 
   public async extractDeclarations(fileName: string, fileLines: DocumentLine[]): Promise<number> {

--- a/src/lib/variables/strategies/stylus-strategy.ts
+++ b/src/lib/variables/strategies/stylus-strategy.ts
@@ -13,7 +13,7 @@ export const DECLARATION_REGEXP = new RegExp(`(?:(^(?:\\$|(?:[\\-_$]+[a-z\\d]+)|
 // export const DECLARATION_REGEXP = new RegExp(`(?:((?:(?:\\$)|(?:[\\-_$]+[a-z\\d]+)|(?:[^\\d]+))([\\-_a-z\d]*))\\s*)=${REGEXP_END}`, 'gi');
 
 class StylusExtractor implements IVariableStrategy {
-  name: string = 'STYLUS_EXTRACTOR';
+  name: string = 'STYLUS';
   private store: VariablesStore = new VariablesStore();
 
   public async extractDeclarations(fileName: string, fileLines: DocumentLine[]): Promise<number> {

--- a/src/lib/variables/variable-decoration.ts
+++ b/src/lib/variables/variable-decoration.ts
@@ -38,7 +38,7 @@ class VariableDecoration {
    * @memberOf ColorDecoration
    */
   get decoration(): TextEditorDecorationType {
-    if (this.hidden) {
+    if (this.hidden || this._decoration === undefined) {
       this.hidden = false;
       this._generateDecorator();
     }

--- a/src/lib/variables/variables-extractor.ts
+++ b/src/lib/variables/variables-extractor.ts
@@ -1,7 +1,4 @@
-import Variable from './variable';
-import Color, { IColor } from '../colors/color';
-import ColorExtractor from '../colors/color-extractor';
-import { dirname } from 'path';
+import Color from '../colors/color';
 import { DocumentLine, LineExtraction, flattenLineExtractionsFlatten } from '../color-util';
 import { IStrategy, Extractor } from '../extractor-mixin';
 
@@ -17,31 +14,19 @@ export interface IVariableStrategy extends IStrategy {
 
 class VariablesExtractor extends Extractor {
 
-  public strategies: IVariableStrategy[];
-  private enabledStrategies: IVariableStrategy[];
-
-  public enableStategies(strategiesToEnable: string[]) {
-    this.enabledStrategies = this.strategies.filter(strategy => {
-      if (strategiesToEnable.find(_ => _ === strategy.name)) {
-        let constructor: any = strategy.constructor;
-        return new constructor();
-      }
-    });
-  }
-
   public async extractVariables(fileName: string, fileLines: DocumentLine[]): Promise < LineExtraction[] > {
-    const colors = await Promise.all(this.enabledStrategies.map(strategy => strategy.extractVariables(fileName, fileLines)));
+    const colors = await Promise.all(this.enabledStrategies.map(strategy => (<IVariableStrategy> strategy).extractVariables(fileName, fileLines)));
     return flattenLineExtractionsFlatten(colors); // should regroup per lines?
   }
 
   public deleteVariableInLine(fileName: string, line: number) {
-    this.enabledStrategies.forEach(strategy => strategy.deleteVariable(fileName, line));
+    this.enabledStrategies.forEach(strategy => (<IVariableStrategy> strategy).deleteVariable(fileName, line));
   }
   public async extractDeclarations(fileName: string, fileLines: DocumentLine[]): Promise<number[]> {
-    return Promise.all(this.enabledStrategies.map(strategy => strategy.extractDeclarations(fileName, fileLines)));
+    return Promise.all(this.enabledStrategies.map(strategy => (<IVariableStrategy> strategy).extractDeclarations(fileName, fileLines)));
   }
   public getVariablesCount(): number {
-    return this.enabledStrategies.reduce((cv, strategy) => cv + strategy.variablesCount(), 0);
+    return this.enabledStrategies.reduce((cv, strategy) => cv + (<IVariableStrategy> strategy).variablesCount(), 0);
   }
 }
 const instance = new VariablesExtractor();

--- a/src/lib/variables/variables-extractor.ts
+++ b/src/lib/variables/variables-extractor.ts
@@ -21,8 +21,6 @@ class VariablesExtractor extends Extractor {
   private enabledStrategies: IVariableStrategy[];
 
   public enableStategies(strategiesToEnable: string[]) {
-    // remove duplicates (if duplicates)
-    strategiesToEnable = Array.from(new Set(strategiesToEnable)); // [...new Set(strategiesToEnable)] // works too
     this.enabledStrategies = this.strategies.filter(strategy => {
       if (strategiesToEnable.find(_ => _ === strategy.name)) {
         let constructor: any = strategy.constructor;

--- a/src/lib/variables/variables-manager.ts
+++ b/src/lib/variables/variables-manager.ts
@@ -67,6 +67,10 @@ class VariablesManager {
     return deco;
   }
 
+  public setupVariablesExtractors(extractors: string[]) {
+    VariablesExtractor.enableStategies(extractors);
+  }
+
   public deleteVariableInLine(fileName: string, line: number) {
     VariablesExtractor.deleteVariableInLine(fileName, line);
   }

--- a/src/lib/variables/variables-manager.ts
+++ b/src/lib/variables/variables-manager.ts
@@ -15,21 +15,24 @@ const INCLUDE_PATTERN = '{**/*.css,**/*.sass,**/*.scss,**/*.less,**/*.pcss,**/*.
 const EXCLUDE_PATTERN = '{**/.git,**/.svn,**/.hg,**/CVS,**/.DS_Store,**/.git,**/node_modules,**/bower_components,**/tmp,**/dist,**/tests}';
 
 class VariablesManager {
+  private statusBar: StatusBarItem;
+
+  constructor() {
+    this.statusBar = window.createStatusBarItem(StatusBarAlignment.Right);
+  }
 
   public async getWorkspaceVariables() {
-    const statusBar: StatusBarItem = window.createStatusBarItem(StatusBarAlignment.Right);
-
-    statusBar.text = 'Fetching files...';
-    statusBar.show();
+    this.statusBar.text = 'Fetching files...';
+    this.statusBar.show();
     try {
       const files: Uri[] = await workspace.findFiles(INCLUDE_PATTERN, EXCLUDE_PATTERN);
-      statusBar.text = `Found ${files.length} files`;
+      this.statusBar.text = `Found ${files.length} files`;
 
       await Promise.all(this.extractFilesVariable(files));
       let variablesCount: number = VariablesExtractor.getVariablesCount();
-      statusBar.text = `Found ${variablesCount} variables`;
+      this.statusBar.text = `Found ${variablesCount} variables`;
     } catch (error) {
-      statusBar.text = 'Variables extraction fail';
+      this.statusBar.text = 'Variables extraction fail';
     }
     return;
   }


### PR DESCRIPTION
This partially solve #143.

I've added two config `colorized_variables` and `colorized_colors` which allows to enabled/disabled colorization for colors/variables. We can now totally disable/enable sass/less/... support or disable/enable colorization for RGB/HSL... colors