### PR TITLE
fix: Link to enable variables support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This extension  your styles files looking for colors and generate a colored back
 
 ![](https://raw.githubusercontent.com/kamikillerto/vscode-colorize/master/assets/demo_variables.gif)
 
-💡 [How to enable variables support](#colorizeactivate_variables_support_beta-boolean-default-false)
+💡 [How to enable variables support](#colorizecolorized_variables)
 
 ## Features
 


### PR DESCRIPTION
The link "how to enable variables support" was broken, now it redirects to the right place on readme