### PR TITLE
Add support for new rgb syntax

### DIFF
--- a/src/lib/colors/strategies/hsl-strategy.ts
+++ b/src/lib/colors/strategies/hsl-strategy.ts
@@ -36,6 +36,7 @@ function extractHSLValue(value: string) {
     .replace(/\)/, '')
     .replace(/%/g, '')
     .replace(/deg/, '')
+    .replace('/', ' ')
     .replaceAll(',', ' ')
     .split(/\s+/)
     .map((c) => parseFloat(c));

--- a/src/lib/colors/strategies/rgb-strategy.ts
+++ b/src/lib/colors/strategies/rgb-strategy.ts
@@ -7,12 +7,16 @@ const R_RED = `(?:\\d{1,3}${DOT_VALUE}?|${DOT_VALUE})`;
 const R_GREEN = R_RED;
 const R_BLUE = R_RED;
 
+const RGB_NEW_SYNTAX = `rgba?\\(\\s*${R_RED}\\s*${R_GREEN}\\s*${R_BLUE}(?:\\s*\\/\\s*(?:\\d{1,3}${DOT_VALUE}?|${ALPHA})?%?)?\\)`;
+const RGB_LEGACY_SYNTAX = `rgb\\(\\s*${R_RED}\\s*,\\s*${R_GREEN}\\s*,\\s*${R_BLUE}\\s*\\)`;
+const RGBA_LEGACY_SYNTAX = `rgba\\(\\s*${R_RED}\\s*,\\s*${R_GREEN}\\s*,\\s*${R_BLUE}\\s*,\\s*${ALPHA}\\s*\\)`;
+
 export const REGEXP = new RegExp(
-  `((?:rgb\\(\\s*${R_RED}\\s*,\\s*${R_GREEN}\\s*,\\s*${R_BLUE}\\s*\\))|(?:rgba\\(\\s*${R_RED}\\s*,\\s*${R_GREEN}\\s*,\\s*${R_BLUE}\\s*,\\s*${ALPHA}\\s*\\)))${EOL}`,
+  `(${RGB_LEGACY_SYNTAX}|${RGBA_LEGACY_SYNTAX}|${RGB_NEW_SYNTAX})${EOL}`,
   'gi',
 );
 export const REGEXP_ONE = new RegExp(
-  `^((?:rgb\\(\\s*${R_RED}\\s*,\\s*${R_GREEN}\\s*,\\s*${R_BLUE}\\s*\\))|(?:rgba\\(\\s*${R_RED}\\s*,\\s*${R_GREEN}\\s*,\\s*${R_BLUE}\\s*,\\s*${ALPHA}\\s*\\)))${EOL}`,
+  `^(${RGB_LEGACY_SYNTAX}|${RGBA_LEGACY_SYNTAX}|${RGB_NEW_SYNTAX})${EOL}`,
   'i',
 );
 

--- a/src/lib/colors/strategies/rgb-strategy.ts
+++ b/src/lib/colors/strategies/rgb-strategy.ts
@@ -7,7 +7,7 @@ const R_RED = `(?:\\d{1,3}${DOT_VALUE}?|${DOT_VALUE})`;
 const R_GREEN = R_RED;
 const R_BLUE = R_RED;
 
-const RGB_NEW_SYNTAX = `rgba?\\(\\s*${R_RED}\\s*${R_GREEN}\\s*${R_BLUE}(?:\\s*\\/\\s*(?:\\d{1,3}${DOT_VALUE}?|${ALPHA})?%?)?\\)`;
+const RGB_NEW_SYNTAX = `rgba?\\(\\s*${R_RED}%?\\s*${R_GREEN}%?\\s*${R_BLUE}%?(?:\\s*\\/\\s*(?:\\d{1,3}${DOT_VALUE}?|${ALPHA})?%?)?\\)`;
 const RGB_LEGACY_SYNTAX = `rgb\\(\\s*${R_RED}\\s*,\\s*${R_GREEN}\\s*,\\s*${R_BLUE}\\s*\\)`;
 const RGBA_LEGACY_SYNTAX = `rgba\\(\\s*${R_RED}\\s*,\\s*${R_GREEN}\\s*,\\s*${R_BLUE}\\s*,\\s*${ALPHA}\\s*\\)`;
 
@@ -24,24 +24,45 @@ function extractRGBA(value: string): number[] {
   const rgba_string = value
     .replace(/rgb(a){0,1}\(/, '')
     .replace(/\)/, '')
-    .replace(/%/g, '')
     .replace('/', ' ')
     .replaceAll(',', ' ');
-  return rgba_string.split(/\s+/).map((c) => parseFloat(c));
+  const values = rgba_string.split(/\s+/);
+
+  const [r, g, b] = values.slice(0, 3).map((v) => {
+    const value = parseFloat(v);
+
+    if (v.includes('%')) {
+      const percentage = value > 100 ? 100 : value;
+
+      return (255 * percentage) / 100;
+    }
+
+    return value;
+  });
+
+  const isRelativeAlpha = /%/.test(values[3]);
+
+  let a = parseFloat(values[3] ?? 1);
+
+  if (!isRelativeAlpha && a > 1) {
+    a = 1;
+  }
+
+  if (isRelativeAlpha && a > 100) {
+    a = 1;
+  }
+
+  if (a > 1) {
+    a = a / 100;
+  }
+  return [r, g, b, a];
 }
 
 function getColor(match: RegExpExecArray) {
   const value = match[1];
   const rgba = extractRGBA(value);
-  let alpha = rgba[3] ?? 1;
 
-  if (alpha > 100) {
-    alpha = 1;
-  }
-
-  if (alpha > 1) {
-    alpha = alpha / 100;
-  }
+  const alpha = rgba[3] ?? 1;
 
   const rgb = rgba.slice(0, 3) as [number, number, number];
   // Check if it's a valid rgb(a) color

--- a/src/lib/colors/strategies/rgb-strategy.ts
+++ b/src/lib/colors/strategies/rgb-strategy.ts
@@ -21,14 +21,28 @@ export const REGEXP_ONE = new RegExp(
 );
 
 function extractRGBA(value: string): number[] {
-  const rgba_string = value.replace(/rgb(a){0,1}\(/, '').replace(/\)/, '');
-  return rgba_string.split(/,/gi).map((c) => parseFloat(c));
+  const rgba_string = value
+    .replace(/rgb(a){0,1}\(/, '')
+    .replace(/\)/, '')
+    .replace(/%/g, '')
+    .replace('/', ' ')
+    .replaceAll(',', ' ');
+  return rgba_string.split(/\s+/).map((c) => parseFloat(c));
 }
 
 function getColor(match: RegExpExecArray) {
   const value = match[1];
   const rgba = extractRGBA(value);
-  const alpha = rgba[3] || 1;
+  let alpha = rgba[3] ?? 1;
+
+  if (alpha > 100) {
+    alpha = 1;
+  }
+
+  if (alpha > 1) {
+    alpha = alpha / 100;
+  }
+
   const rgb = rgba.slice(0, 3) as [number, number, number];
   // Check if it's a valid rgb(a) color
   if (rgb.every((c) => c <= 255)) {
@@ -40,3 +54,4 @@ function getColor(match: RegExpExecArray) {
 
 const strategy = new ColorStrategy('RGB', REGEXP, REGEXP_ONE, getColor);
 ColorExtractor.registerStrategy(strategy);
+export default strategy;

--- a/test/unit/color-extractor-strategies/rgb-extrator.test.ts
+++ b/test/unit/color-extractor-strategies/rgb-extrator.test.ts
@@ -5,6 +5,23 @@ import { REGEXP } from '../../../src/lib/colors/strategies/rgb-strategy';
 import { regex_exec } from '../../test-util';
 
 describe('Test rgb(a) color Regex', () => {
+  it('Should match the new syntax', function () {
+    assert.equal(regex_exec('rgb(255 255 255)', REGEXP)[1], 'rgb(255 255 255)');
+    assert.equal(
+      regex_exec('rgb(255 255 255 / 50%)', REGEXP)[1],
+      'rgb(255 255 255 / 50%)',
+    );
+    assert.equal(regex_exec('rgba(0 255 255)', REGEXP)[1], 'rgba(0 255 255)');
+    assert.equal(
+      regex_exec('rgba(0 255 255 / 50)', REGEXP)[1],
+      'rgba(0 255 255 / 50)',
+    );
+
+    assert.equal(
+      regex_exec('rgba(.1 25.5 2.55 / 50)', REGEXP)[1],
+      'rgba(.1 25.5 2.55 / 50)',
+    );
+  });
   it('Should match a simple rgb color', function () {
     assert.equal(
       regex_exec('rgb(123, 123, 123)', REGEXP)[1],

--- a/test/unit/color-extractor-strategies/rgb-extrator.test.ts
+++ b/test/unit/color-extractor-strategies/rgb-extrator.test.ts
@@ -3,6 +3,8 @@ import { describe, it } from 'mocha';
 
 import { REGEXP } from '../../../src/lib/colors/strategies/rgb-strategy';
 import { regex_exec } from '../../test-util';
+import RGBStrategy from '../../../src/lib/colors/strategies/rgb-strategy';
+import Color from '../../../src/lib/colors/color';
 
 describe('Test rgb(a) color Regex', () => {
   it('Should match the new syntax', function () {
@@ -152,5 +154,199 @@ describe('Test rgb(a) color Regex', () => {
       regex_exec('rgba(.123, 123, 123, 1)', REGEXP)[1],
       'rgba(.123, 123, 123, 1)',
     );
+  });
+});
+
+describe('Extract color', () => {
+  (
+    [
+      {
+        input: 'rgb(255 255 255)',
+        expected: {
+          rgb: [255, 255, 255],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'rgb(255 255 255 / 50%)',
+        expected: {
+          rgb: [255, 255, 255],
+          alpha: 0.5,
+        },
+      },
+      {
+        input: 'rgb(255 255 255 / 255%)',
+        expected: {
+          rgb: [255, 255, 255],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'rgba(0 255 255)',
+        expected: {
+          rgb: [0, 255, 255],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'rgba(0 255 255 / 50)',
+        expected: {
+          rgb: [0, 255, 255],
+          alpha: 0.5,
+        },
+      },
+      {
+        input: 'rgba(.1 25.5 2.55 / 50)',
+        expected: {
+          rgb: [0.1, 25.5, 2.55],
+          alpha: 0.5,
+        },
+      },
+      {
+        input: 'rgb(123, 123, 123)',
+        expected: {
+          rgb: [123, 123, 123],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'rgba(123, 123, 123, 0)',
+        expected: {
+          rgb: [123, 123, 123],
+          alpha: 0,
+        },
+      },
+      {
+        input: 'rgba(123, 123, 123, 0.3)',
+        expected: {
+          rgb: [123, 123, 123],
+          alpha: 0.3,
+        },
+      },
+      {
+        input: 'rgba(123, 123, 123, .3)',
+        expected: {
+          rgb: [123, 123, 123],
+          alpha: 0.3,
+        },
+      },
+      {
+        input: 'rgba(123, 123, 123, 1)',
+        expected: {
+          rgb: [123, 123, 123],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'rgba(123, 123, 123, 1.0)',
+        expected: {
+          rgb: [123, 123, 123],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'rgb(12.3, 123, 123)',
+        expected: {
+          rgb: [12.3, 123, 123],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'rgb(123, 12.3, 123)',
+        expected: {
+          rgb: [123, 12.3, 123],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'rgb(123, 123, 12.3)',
+        expected: {
+          rgb: [123, 123, 12.3],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'rgb(123, 123, 12.333333)',
+        expected: {
+          rgb: [123, 123, 12.333333],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'rgb(12.3, 12.3, 12.3)',
+        expected: {
+          rgb: [12.3, 12.3, 12.3],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'rgb(.3, 12.3, 12.3)',
+        expected: {
+          rgb: [0.3, 12.3, 12.3],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'rgba(12.3, 123, 123, 0)',
+        expected: {
+          rgb: [12.3, 123, 123],
+          alpha: 0,
+        },
+      },
+      {
+        input: 'rgba(123, 12.3, 123, 0)',
+        expected: {
+          rgb: [123, 12.3, 123],
+          alpha: 0,
+        },
+      },
+      {
+        input: 'rgba(123, 123, 12.3, 0)',
+        expected: {
+          rgb: [123, 123, 12.3],
+          alpha: 0,
+        },
+      },
+      {
+        input: 'rgba(123, 123, 123, 1.0)',
+        expected: {
+          rgb: [123, 123, 123],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'rgba(123, 123, 123, 1.00)',
+        expected: {
+          rgb: [123, 123, 123],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'rgba(123, 123, 123, 1)',
+        expected: {
+          rgb: [123, 123, 123],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'rgba(.123, 123, 123, 1)',
+        expected: {
+          rgb: [0.123, 123, 123],
+          alpha: 1,
+        },
+      },
+    ] satisfies Array<{
+      input: string;
+      expected: {
+        rgb: [number, number, number];
+        alpha: number;
+      };
+    }>
+  ).forEach((test) => {
+    it(`Should correctly extract '${test.input}'`, function () {
+      const color = RGBStrategy.extractColor(test.input) as Color;
+      assert.deepEqual(color.rgb, test.expected.rgb);
+      assert.deepEqual(color.alpha, test.expected.alpha);
+    });
   });
 });

--- a/test/unit/color-extractor-strategies/rgb-extrator.test.ts
+++ b/test/unit/color-extractor-strategies/rgb-extrator.test.ts
@@ -9,6 +9,7 @@ import Color from '../../../src/lib/colors/color';
 describe('Test rgb(a) color Regex', () => {
   it('Should match the new syntax', function () {
     assert.equal(regex_exec('rgb(255 255 255)', REGEXP)[1], 'rgb(255 255 255)');
+    assert.equal(regex_exec('rgb(2% 13% 255)', REGEXP)[1], 'rgb(2% 13% 255)');
     assert.equal(
       regex_exec('rgb(255 255 255 / 50%)', REGEXP)[1],
       'rgb(255 255 255 / 50%)',
@@ -192,14 +193,21 @@ describe('Extract color', () => {
         input: 'rgba(0 255 255 / 50)',
         expected: {
           rgb: [0, 255, 255],
-          alpha: 0.5,
+          alpha: 1,
         },
       },
       {
         input: 'rgba(.1 25.5 2.55 / 50)',
         expected: {
           rgb: [0.1, 25.5, 2.55],
-          alpha: 0.5,
+          alpha: 1,
+        },
+      },
+      {
+        input: 'rgb(2% 13% 255)',
+        expected: {
+          rgb: [5.1, 33.15, 255],
+          alpha: 1,
         },
       },
       {


### PR DESCRIPTION
Adding support for rgb(a) "new" syntax

```
rgb(255 255 255)
rgb(255 255 255 / 50%)
rgb(2% 10% 25%)
rgb(3% 255 255 / 50%)
```