### PR TITLE
Fix HSL new syntaxe support

### DIFF
--- a/test/unit/color-extractor-strategies/hsl-extractor.test.ts
+++ b/test/unit/color-extractor-strategies/hsl-extractor.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'mocha';
 import { REGEXP } from '../../../src/lib/colors/strategies/hsl-strategy';
 import { regex_exec } from '../../test-util';
 import HSLStrategy from '../../../src/lib/colors/strategies/hsl-strategy';
+import Color from '../../../src/lib/colors/color';
 
 describe('Test hsl(a) color Regex', () => {
   it('Should match new hsl syntax', function () {
@@ -165,115 +166,230 @@ describe('Test hsl(a) color Regex', () => {
 });
 
 describe('Extract color', () => {
-  it('Should match new hsl syntax', function () {
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsl(120deg 75% 25%)')?.rgb,
-      [16, 112, 16],
-    );
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsl(120 75 25)')?.rgb,
-      [16, 112, 16],
-    ); /* deg and % units are optional */
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsl(120deg 75% 25% / 60%)')?.rgb,
-      [16, 112, 16],
-    );
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsl(120deg 75% 25)')?.rgb,
-      [16, 112, 16],
-    );
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsl(120deg 75 25%)')?.rgb,
-      [16, 112, 16],
-    );
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsl(120 75% 25%)')?.rgb,
-      [16, 112, 16],
-    );
-    // assert.equal(
-    //   regex_exec('hsl(none 75% 25%)'),
-    //   'hsl(120deg 75% 25% / 60%)',
-    // ); // Not supported yet
-  });
-  it('Should match a simple hsl color', function () {
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsl(200, 10%, 10%)')?.rgb,
-      [23, 26, 28],
-    );
-  });
-  it('Should match a simple hsla color', function () {
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsla(200, 10%, 10%, 0)')?.rgb,
-      [23, 26, 28],
-    );
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsla(200, 10%, 10%, 0.3)')?.rgb,
-      [23, 26, 28],
-    );
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsla(200, 10%, 10%, .3)')?.rgb,
-      [23, 26, 28],
-    );
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsla(200, 10%, 10%, 1)')?.rgb,
-      [23, 26, 28],
-    );
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsla(200, 10%, 10%, 1.0)')?.rgb,
-      [23, 26, 28],
-    );
-  });
-  it('Should accept dot values (hsl)', function () {
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsl(200.1, 10%, 10%)')?.rgb,
-      [23, 26, 28],
-    );
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsl(200, 10.1%, 10%)')?.rgb,
-      [23, 26, 28],
-    );
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsl(200, 10%, 10.1%)')?.rgb,
-      [23, 27, 28],
-    );
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsl(200, 10%, 10.1111111%)')?.rgb,
-      [23, 27, 28],
-    );
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsl(200.1, 10.1%, 10.1%)')?.rgb,
-      [23, 27, 28],
-    );
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsl(.1, 10.1%, 10.1%)')?.rgb,
-      [28, 23, 23],
-    );
-  });
-
-  it('Should accept dot values (hsla)', function () {
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsla(200.1, 10%, 10%, 1)')?.rgb,
-      [23, 26, 28],
-    );
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsla(200, 10.1%, 10%, 1)')?.rgb,
-      [23, 26, 28],
-    );
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsla(200, 10%, 10.1%, 1)')?.rgb,
-      [23, 27, 28],
-    );
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsla(200, 10%, 10.1%, 1.0)')?.rgb,
-      [23, 27, 28],
-    );
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsla(200.1, 10.1%, 10.1%, 1)')?.rgb,
-      [23, 27, 28],
-    );
-    assert.deepEqual(
-      HSLStrategy.extractColor('hsla(.1, 10.1%, 10.1%, 1)')?.rgb,
-      [28, 23, 23],
-    );
+  (
+    [
+      {
+        input: 'hsl(120deg 75% 25%)',
+        expected: {
+          rgb: [16, 112, 16],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsl(120 75 25)',
+        expected: {
+          rgb: [16, 112, 16],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsl(120deg 75% 25% / 60%)',
+        expected: {
+          rgb: [16, 112, 16],
+          alpha: 0.6,
+        },
+      },
+      {
+        input: 'hsl(120deg 75% 25)',
+        expected: {
+          rgb: [16, 112, 16],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsl(360deg 75% 25)',
+        expected: {
+          rgb: [112, 16, 16],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsl(520deg 75% 25)',
+        expected: {
+          rgb: [16, 112, 80],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsl(120deg 75 25%)',
+        expected: {
+          rgb: [16, 112, 16],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsl(120 75% 25%)',
+        expected: {
+          rgb: [16, 112, 16],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsl(200, 10%, 10%)',
+        expected: {
+          rgb: [23, 26, 28],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsla(200, 10%, 10%, 0)',
+        expected: {
+          rgb: [23, 26, 28],
+          alpha: 0,
+        },
+      },
+      {
+        input: 'hsla(200, 10%, 10%, 0.3)',
+        expected: {
+          rgb: [23, 26, 28],
+          alpha: 0.3,
+        },
+      },
+      {
+        input: 'hsla(200, 10%, 10%, .3)',
+        expected: {
+          rgb: [23, 26, 28],
+          alpha: 0.3,
+        },
+      },
+      {
+        input: 'hsla(200, 10%, 10%, 1)',
+        expected: {
+          rgb: [23, 26, 28],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsla(200, 10%, 10%, 1.0)',
+        expected: {
+          rgb: [23, 26, 28],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsl(200.1, 10%, 10%)',
+        expected: {
+          rgb: [23, 26, 28],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsl(200, 10.1%, 10%)',
+        expected: {
+          rgb: [23, 26, 28],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsl(200, 10%, 10.1%)',
+        expected: {
+          rgb: [23, 27, 28],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsl(200, 10%, 10.1111111%)',
+        expected: {
+          rgb: [23, 27, 28],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsl(200.1, 10.1%, 10.1%)',
+        expected: {
+          rgb: [23, 27, 28],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsl(.1, 10.1%, 10.1%)',
+        expected: {
+          rgb: [28, 23, 23],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsla(200.1, 10%, 10%, 1)',
+        expected: {
+          rgb: [23, 26, 28],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsla(200, 10.1%, 10%, 1)',
+        expected: {
+          rgb: [23, 26, 28],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsla(200, 10%, 10.1%, 1)',
+        expected: {
+          rgb: [23, 27, 28],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsla(200, 10%, 10.1%, 1.0)',
+        expected: {
+          rgb: [23, 27, 28],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsla(200.1, 10.1%, 10.1%, 1)',
+        expected: {
+          rgb: [23, 27, 28],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsla(.1, 10.1%, 10.1%, 1)',
+        expected: {
+          rgb: [28, 23, 23],
+          alpha: 1,
+        },
+      },
+      {
+        input: 'hsl(0.3turn 60% 45% / .7)',
+        expected: {
+          rgb: [74, 184, 46],
+          alpha: 0.7,
+        },
+      },
+      {
+        input: 'hsl(12.3turn 60% 45% / .7)',
+        expected: {
+          rgb: [74, 184, 46],
+          alpha: 0.7,
+        },
+      },
+      {
+        input: 'hsl(1turn 60% 45% / .7)',
+        expected: {
+          rgb: [184, 46, 46],
+          alpha: 0.7,
+        },
+      },
+      {
+        input: 'hsl(12turn 60% 45% / .7)',
+        expected: {
+          rgb: [184, 46, 46],
+          alpha: 0.7,
+        },
+      },
+    ] satisfies Array<{
+      input: string;
+      expected: {
+        rgb: [number, number, number];
+        alpha: number;
+      };
+    }>
+  ).forEach((test) => {
+    it(`Should correctly extract '${test.input}'`, function () {
+      const color = HSLStrategy.extractColor(test.input) as Color;
+      assert.deepEqual(color.rgb, test.expected.rgb);
+      assert.deepEqual(color.alpha, test.expected.alpha);
+    });
   });
 });


### PR DESCRIPTION
Correctly extract alpha value when `%` ais used.
Also add support for `turn` unit in hue value
